### PR TITLE
Ignore *.iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ buildNumber.properties
 
 .local/
 .idea/
+*.iml


### PR DESCRIPTION
When we create the idea project directly in the checkout, .iml files should be ignored.